### PR TITLE
New candidate spaces (bidirectional; forward and backward)

### DIFF
--- a/doc/examples/model_selection/observables.tsv
+++ b/doc/examples/model_selection/observables.tsv
@@ -1,2 +1,2 @@
 observableId	observableFormula	noiseFormula
-obs_x2	x2+k4	noiseParameter1_obs_x2
+obs_x2	x2+k4+k5	noiseParameter1_obs_x2

--- a/doc/examples/model_selection/parameters.tsv
+++ b/doc/examples/model_selection/parameters.tsv
@@ -3,4 +3,5 @@ k1	k_{1}	lin	0	1e3	0.2	1
 k2	k_{2}	lin	0	1e3	0.1	1
 k3	k_{3}	lin	0	1e3	0	1
 k4	k_{4}	lin	0	1e3	0	0
+k5	k_{5}	lin	0	1e3	0	0
 sigma_x2	\sigma_{x2}	lin	1e-5	1e3	0.15	1

--- a/petab_select/candidate_space.py
+++ b/petab_select/candidate_space.py
@@ -1,7 +1,7 @@
 """Classes and methods related to candidate spaces."""
 import abc
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Callable
 
 import numpy as np
 from more_itertools import one
@@ -11,6 +11,8 @@ from .constants import (
     VIRTUAL_INITIAL_MODEL,
     VIRTUAL_INITIAL_MODEL_METHODS,
     Method,
+    METHOD,
+    MODELS,
 )
 from .handlers import TYPE_LIMIT, LimitHandler
 from .misc import snake_case_to_camel_case
@@ -38,11 +40,25 @@ class CandidateSpace(abc.ABC):
             are added to `exclusions`.
         limit:
             A handler to limit the number of accepted models.
+        method:
+            The model selection method of the candidate space.
+        governing_method:
+            Used to store the search method that governs the choice of method during
+            a search. In some cases, this is always the same as the method attribute.
+            An example of a difference is in the bidirectional method, where `governing_method`
+            stores the bidirectional method, whereas `method` may also store the forward or
+            backward methods.
+        retry_model_space_search_if_no_models:
+            Whether a search with a candidate space should be repeated upon failure.
+            Useful for the `BidirectionalCandidateSpace`, which switches directions
+            upon failure.
         #limited:
         #    A descriptor that handles the limit on the number of accepted models.
         #limit:
         #    Models will fail `self.consider` if `len(self.models) >= limit`.
     """
+    method: Method = None
+    retry_model_space_search_if_no_models: bool = False
 
     def __init__(
         self,
@@ -55,6 +71,8 @@ class CandidateSpace(abc.ABC):
             current=self.n_accepted,
             limit=limit,
         )
+        # Each candidate class specifies this as a class attribute.
+        self.governing_method = self.method
         self.reset(predecessor_model=predecessor_model, exclusions=exclusions)
 
     def is_plausible(self, model: Model) -> bool:
@@ -215,7 +233,7 @@ class CandidateSpace(abc.ABC):
     def get_predecessor_model(self):
         return self.predecessor_model
 
-    def set_exclusions(self, exclusions: Union[List[Any], None]):
+    def set_exclusions(self, exclusions: Union[List[str], None]):
         # TODO change to List[str] for hashes?
         self.exclusions = exclusions
         if self.exclusions is None:
@@ -231,11 +249,25 @@ class CandidateSpace(abc.ABC):
     def get_limit(self):
         return self.limit.get_limit()
 
+    def wrap_search_subspaces(self, search_subspaces: Callable[[], None]):
+        """Decorate the subspace searches of a model space.
+
+        Used by candidate spaces to perform changes that alter the search.
+        See `BidirectionalCandidateSpace` for an example, where it's used to switch directions.
+
+        Args:
+            search_subspaces:
+                The method that searches the subspaces of a model space.
+        """
+        def wrapper():
+            search_subspaces()
+        return wrapper
+
     def reset(
         self,
         predecessor_model: Optional[Union[Model, str, None]] = None,
         # FIXME change `Any` to some `TYPE_MODEL_HASH` (e.g. union of str/int/float)
-        exclusions: Optional[Union[List[Any], None]] = None,
+        exclusions: Optional[Union[List[str], None]] = None,
         limit: TYPE_LIMIT = None,
     ) -> None:
         """Reset the candidate models, optionally reinitialize with a model.
@@ -408,6 +440,117 @@ class BackwardCandidateSpace(ForwardCandidateSpace):
     direction = -1
 
 
+class BidirectionalCandidateSpace(ForwardCandidateSpace):
+    """The bidirectional method class.
+
+    Attributes:
+        method_history:
+            The history of models that were found at each search.
+            A list of dictionaries, where each dictionary contains keys for the `METHOD`
+            and the list of `MODELS`.
+    """
+
+    method = Method.BIDIRECTIONAL
+    retry_model_space_search_if_no_models = True
+
+    def __init__(
+        self,
+        *args,
+        initial_method: Method = Method.FORWARD,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        # FIXME cannot access from CLI
+        self.initial_method = initial_method
+
+        self.history: List[Dict[str, Union[Method, List[Model]]]] = []
+
+    def update_method(self, method: Method):
+        if method == Method.FORWARD:
+            self.direction = 1
+        elif method == Method.BACKWARD:
+            self.direction = -1
+        else:
+            raise NotImplementedError(
+                f'Bidirectional direction must be either `Method.FORWARD` or `Method.BACKWARD`, not {method}.'
+            )
+
+        self.method = method
+
+    def switch_method(self):
+        if self.method == Method.FORWARD:
+            method = Method.BACKWARD
+        elif self.method == Method.BACKWARD:
+            method = Method.FORWARD
+
+        self.update_method(method=method)
+
+    def setup_before_model_subspaces_search(self):
+        # If previous search found no models, then switch method.
+        previous_search = None if not self.history else self.history[-1]
+        if previous_search is None:
+            self.update_method(self.initial_method)
+            return
+
+        self.update_method(previous_search[METHOD])
+        if not previous_search[MODELS]:
+            self.switch_method()
+            self.retry_model_space_search_if_no_models = False
+
+    def setup_after_model_subspaces_search(self):
+        current_search = {
+            METHOD: self.method,
+            MODELS: self.models,
+        }
+        self.history.append(current_search)
+        self.method = self.governing_method
+
+    def wrap_search_subspaces(self, search_subspaces):
+        def wrapper():
+            def iterate():
+                self.setup_before_model_subspaces_search()
+                search_subspaces()
+                self.setup_after_model_subspaces_search()
+
+            # Repeat until models are found or switching doesn't help.
+            iterate()
+            while (
+                not self.models
+                and self.retry_model_space_search_if_no_models
+            ):
+                iterate()
+
+            # Reset flag for next time.
+            self.retry_model_space_search_if_no_models = True
+        return wrapper
+
+
+# TODO rewrite so BidirectionalCandidateSpace inherits from ForwardAndBackwardCandidateSpace
+#      instead
+class ForwardAndBackwardCandidateSpace(BidirectionalCandidateSpace):
+    method = Method.FORWARD_AND_BACKWARD
+    governing_method = Method.FORWARD_AND_BACKWARD
+    retry_model_space_search_if_no_models = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, initial_method=None)
+
+    def wrap_search_subspaces(self, search_subspaces):
+        def wrapper():
+            for method in [Method.FORWARD, Method.BACKWARD]:
+                self.update_method(method=method)
+                search_subspaces()
+                self.setup_after_model_subspaces_search()
+        return wrapper
+
+    # Disable unused interface
+    setup_before_model_subspaces_search = None
+    switch_method = None
+    def setup_after_model_space_search(self):
+        pass
+
+
 class LateralCandidateSpace(ForwardCandidateSpace):
     """Find models with the same number of estimated parameters."""
 
@@ -463,8 +606,10 @@ class BruteForceCandidateSpace(CandidateSpace):
 candidate_space_classes = [
     ForwardCandidateSpace,
     BackwardCandidateSpace,
+    BidirectionalCandidateSpace,
     LateralCandidateSpace,
     BruteForceCandidateSpace,
+    ForwardAndBackwardCandidateSpace,
 ]
 
 

--- a/petab_select/constants.py
+++ b/petab_select/constants.py
@@ -30,6 +30,7 @@ MODEL_SUBSPACE_ID = 'model_subspace_id'
 MODEL_SUBSPACE_INDICES = 'model_subspace_indices'
 MODEL_CODE = 'model_code'
 MODEL_HASH = 'model_hash'
+MODEL_HASHES = 'model_hashes'
 # If `predecessor_model_hash` is defined for a model, it is the ID of the model that the
 # current model was/is to be compared to. This is part of the result and is
 # only (optionally) set by the PEtab calibration tool. It is not defined by the
@@ -94,6 +95,7 @@ VERSION = 'version'
 MODEL_SPACE_FILES = 'model_space_files'
 
 MODEL = 'model'
+MODELS = 'models'
 
 # Parameters can be fixed to a value, or estimated if indicated with the string
 # `ESTIMATE`.
@@ -115,6 +117,7 @@ class Method(str, Enum):
     BIDIRECTIONAL = 'bidirectional'
     BRUTE_FORCE = 'brute_force'
     FORWARD = 'forward'
+    FORWARD_AND_BACKWARD = 'forward_and_backward'
     LATERAL = 'lateral'
 
 
@@ -134,15 +137,23 @@ STEPWISE_METHODS = [
     Method.BACKWARD,
     Method.BIDIRECTIONAL,
     Method.FORWARD,
+    Method.FORWARD_AND_BACKWARD,
     Method.LATERAL,
 ]
 # Methods that require an initial model.
 INITIAL_MODEL_METHODS = [
     Method.BACKWARD,
+    Method.BIDIRECTIONAL,
     Method.FORWARD,
+    Method.FORWARD_AND_BACKWARD,
     Method.LATERAL,
 ]
 
 # Virtual initial models can be used to initialize some initial model methods.
 VIRTUAL_INITIAL_MODEL = 'virtual_initial_model'
-VIRTUAL_INITIAL_MODEL_METHODS = [Method.FORWARD, Method.BACKWARD]
+VIRTUAL_INITIAL_MODEL_METHODS = [
+    Method.BACKWARD,
+    Method.BIDIRECTIONAL,
+    Method.FORWARD,
+    Method.FORWARD_AND_BACKWARD,
+]

--- a/petab_select/model_space.py
+++ b/petab_select/model_space.py
@@ -180,6 +180,25 @@ class ModelSpace:
         model_space = ModelSpace(model_subspaces=model_subspaces)
         return model_space
 
+    @staticmethod
+    def from_df(
+        df: pd.DataFrame,
+        parent_path: TYPE_PATH = None,
+    ):
+        model_subspaces = []
+        for model_subspace_id, definition in df.iterrows():
+            model_subspaces.append(
+                ModelSubspace.from_definition(
+                    model_subspace_id=model_subspace_id,
+                    definition=definition,
+                    parent_path=parent_path,
+                )
+            )
+        model_space = ModelSpace(model_subspaces=model_subspaces)
+        return model_space
+
+    # TODO: `to_df` / `to_file`
+
     def search(
         self,
         candidate_space: CandidateSpace,
@@ -201,18 +220,22 @@ class ModelSpace:
             exclude:
                 Whether to exclude the new candidates from the model subspaces.
         """
-        # TODO change dict to list of subspaces. Each subspace should manage its own
-        #      ID
-        for model_subspace in self.model_subspaces.values():
-            model_subspace.search(candidate_space=candidate_space, limit=limit)
-            if len(candidate_space.models) == limit:
-                break
-            elif len(candidate_space.models) > limit:
-                raise ValueError(
-                    'An unknown error has occurred. Too many models were '
-                    f'generated. Requested limit: {limit}. Number of '
-                    f'generated models: {len(candidate_space.models)}.'
-                )
+        @candidate_space.wrap_search_subspaces
+        def search_subspaces():
+            # TODO change dict to list of subspaces. Each subspace should manage its own
+            #      ID
+            for model_subspace in self.model_subspaces.values():
+                model_subspace.search(candidate_space=candidate_space, limit=limit)
+                if len(candidate_space.models) == limit:
+                    break
+                elif len(candidate_space.models) > limit:
+                    raise ValueError(
+                        'An unknown error has occurred. Too many models were '
+                        f'generated. Requested limit: {limit}. Number of '
+                        f'generated models: {len(candidate_space.models)}.'
+                    )
+
+        search_subspaces()
 
         ## FIXME implement source_path.. somewhere
         # if self.source_path is not None:
@@ -264,7 +287,8 @@ def get_model_space_df(df: Union[TYPE_PATH, pd.DataFrame]) -> pd.DataFrame:
     # model_space_df = pd.read_csv(filename, sep='\t', index_col=MODEL_SUBSPACE_ID)  # FIXME
     if isinstance(df, get_args(TYPE_PATH)):
         df = pd.read_csv(df, sep='\t')
-    df.set_index([MODEL_SUBSPACE_ID], inplace=True)
+    if df.index.name != MODEL_SUBSPACE_ID:
+        df.set_index([MODEL_SUBSPACE_ID], inplace=True)
     return df
 
 

--- a/test/candidate_space/test_candidate_space.py
+++ b/test/candidate_space/test_candidate_space.py
@@ -1,0 +1,205 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from more_itertools import one
+
+import petab_select
+from petab_select.candidate_space import (
+    #BackwardCandidateSpace,
+    #BruteForceCandidateSpace,
+    #ForwardCandidateSpace,
+    BidirectionalCandidateSpace,
+    #ForwardAndBackwardCandidateSpace,
+    #LateralCandidateSpace,
+)
+from petab_select.constants import (
+    ESTIMATE,
+    MODEL_SUBSPACE_ID,
+    PARAMETER_VALUE_DELIMITER,
+    PETAB_YAML,
+    Criterion,
+    MODELS,
+)
+from petab_select.model import Model, default_compare
+from petab_select.model_subspace import ModelSubspace
+from petab_select.model_space import get_model_space_df, ModelSpace
+
+
+@pytest.fixture
+def ordered_model_parameterizations():
+    good_models_ascending = [
+        # forward
+        '00000',
+        '10000',
+        '11000',
+        '11100',
+        '11110',
+        # backward
+        '01110',
+        '01100',
+        # forward
+        '01101',
+        '01111',
+        # backward
+        '00111',
+        '00011',
+    ]
+    bad_models = [
+        '01011',
+        '11011',
+    ]
+
+    # All good models are unique
+    assert len(set(good_models_ascending)) == len(good_models_ascending)
+    # All bad models are unique
+    assert len(set(bad_models)) == len(bad_models)
+    # No models are defined as both bad and good.
+    assert not set(good_models_ascending).intersection(bad_models)
+
+    return good_models_ascending, bad_models
+
+
+@pytest.fixture
+def calibrated_model_space(ordered_model_parameterizations):
+    good_models_ascending, bad_models = ordered_model_parameterizations
+
+    # As good models are ordered ascending by "goodness", and criteria
+    # decreases for better models, the criteria decreases as the index increases.
+    good_model_criteria = {
+        model: 100 - index
+        for index, model in enumerate(good_models_ascending)
+    }
+    # All bad models are currently set to the same "bad" criterion value.
+    bad_model_criteria = {
+        model: 1000
+        for model in bad_models
+    }
+
+    model_criteria = {
+        **good_model_criteria,
+        **bad_model_criteria,
+    }
+    return model_criteria
+
+
+@pytest.fixture
+def model_space(calibrated_model_space) -> pd.DataFrame:
+    data = {
+        "model_subspace_id": [],
+        "petab_yaml": [],
+        "k1": [],
+        "k2": [],
+        "k3": [],
+        "k4": [],
+        "k5": [],
+    }
+
+    for model in calibrated_model_space:
+        data["model_subspace_id"].append(f"model_subspace_{model}")
+        data["petab_yaml"].append(
+            Path(__file__).parent.parent.parent
+            / 'doc'
+            / 'examples'
+            / 'model_selection'
+            / 'petab_problem.yaml'
+        )
+        k1, k2, k3, k4, k5 = ['0' if parameter == '0' else ESTIMATE for parameter in model]
+        data["k1"].append(k1)
+        data["k2"].append(k2)
+        data["k3"].append(k3)
+        data["k4"].append(k4)
+        data["k5"].append(k5)
+    df = pd.DataFrame(data=data)
+    df = get_model_space_df(df)
+    model_space = ModelSpace.from_df(df)
+    return model_space
+
+
+def test_bidirectional(model_space, calibrated_model_space, ordered_model_parameterizations):
+    criterion = Criterion.AIC
+    model_id_length = one(set([len(model_id) for model_id in calibrated_model_space]))
+
+    candidate_space = BidirectionalCandidateSpace()
+    calibrated_models = []
+
+    # Perform bidirectional search until no more models are found.
+    search_iterations = 0
+    while True:
+        new_calibrated_models = []
+        search_iterations += 1
+
+        # Get models.
+        model_space.search(candidate_space)
+
+        # Calibrate models.
+        for model in candidate_space.models:
+            model_id = model.model_subspace_id[-model_id_length:]
+            model.set_criterion(criterion=criterion, value=calibrated_model_space[model_id])
+            new_calibrated_models.append(model)
+
+        # End if no more models were found.
+        if not new_calibrated_models:
+            break
+
+        # Get next predecessor model as best of new models.
+        best_new_model = None
+        for model in new_calibrated_models:
+            if best_new_model is None:
+                best_new_model = model
+                continue
+            if default_compare(model0=best_new_model, model1=model, criterion=criterion):
+                best_new_model = model
+
+        # Set next predecessor and exclusions.
+        calibrated_model_hashes = [model.get_hash() for model in calibrated_models]
+        candidate_space.reset(
+            predecessor_model=best_new_model,
+            exclusions=calibrated_model_hashes,
+        )
+
+        # exclude calibrated model hashes from model space too?
+        model_space.exclude_model_hashes(model_hashes=calibrated_model_hashes)
+
+    # Check that expected models are found at each iteration.
+    good_model_parameterizations_ascending, bad_model_parameterizations = ordered_model_parameterizations
+    search_iteration = 0
+    for history_item in candidate_space.history:
+        models = history_item[MODELS]
+        if not models:
+            continue
+        model_parameterizations = [model.model_subspace_id[-5:] for model in models]
+
+        good_model_parameterization = good_model_parameterizations_ascending[search_iteration]
+        # The expected good model was found.
+        assert good_model_parameterization in model_parameterizations
+        model_parameterizations.remove(good_model_parameterization)
+
+        if search_iteration == 0:
+            # All parameterizations have been correctly identified and removed.
+            assert not model_parameterizations
+            search_iteration += 1
+            continue
+
+        previous_model_parameterization = good_model_parameterizations_ascending[search_iteration-1]
+
+        # The expected bad model is also found.
+        # If a bad model is the same dimension and also represents a similar stepwise move away from the previous
+        # model parameterization, it should also be in the parameterizations.
+        for bad_model_parameterization in bad_model_parameterizations:
+            # Skip if different dimensions
+            if sum(map(int, bad_model_parameterization)) != sum(map(int, good_model_parameterization)):
+                continue
+            # Skip if different distances from previous model parameterization
+            if sum([a != b for a,b in zip(bad_model_parameterization, previous_model_parameterization)]) != sum([a != b for a,b in zip(good_model_parameterization, previous_model_parameterization)]):
+                continue
+            assert bad_model_parameterization in model_parameterizations
+            model_parameterizations.remove(bad_model_parameterization)
+
+        # All parameterizations have been correctly identified and removed.
+        assert not model_parameterizations
+        search_iteration += 1
+
+        # End test if all good models were found in the correct order.
+        if search_iteration >= len(good_model_parameterizations_ascending):
+            break


### PR DESCRIPTION
- bidirectional candidate space
    - moves as far in one direction before no further models are found, then moves switches, until switching twice in a row yields no good models
- forward and backward candidate space
    - considers all models that are a valid forward or backward move
    - currently might be that, e.g., the closest "forward models" are `+1` estimated parameters, and the closest "backward models" are `-3` estimated parameters: these models are part of the same iteration
- candidate spaces can now implement a wrapper for the subspaces search
    - implemented for the direction switches in the new candidate spaces
- added `ModelSpace.from_df`
- added test for bidirectional candidate space
    - for this test: added a parameter to the example problem in `doc/examples/model_selection`