### PR TITLE
Fix multi-subspace stepwise moves

### DIFF
--- a/petab_select/model_subspace.py
+++ b/petab_select/model_subspace.py
@@ -232,8 +232,10 @@ class ModelSubspace(PetabMixin):
         if candidate_space.predecessor_model == VIRTUAL_INITIAL_MODEL:
             if candidate_space.method == Method.FORWARD:
                 old_estimated_all = set()
+                old_fixed_all = set(self.parameters)
             elif candidate_space.method == Method.BACKWARD:
                 old_estimated_all = set(self.parameters)
+                old_fixed_all = set()
             else:
                 # Should already be handled elsewhere (e.g.
                 # `self.check_compatibility_stepwise_method`).
@@ -242,10 +244,16 @@ class ModelSubspace(PetabMixin):
                 )
         else:
             old_estimated_all = set()
+            old_fixed_all = set()
             if isinstance(candidate_space.predecessor_model, Model):
                 old_estimated_all = (
                     candidate_space.predecessor_model.get_estimated_parameter_ids_all()
                 )
+                old_fixed_all = [
+                    parameter_id
+                    for parameter_id in self.parameters_all
+                    if parameter_id not in old_estimated_all
+                ]
 
         # Parameters that are fixed in the candidate space
         # predecessor model but are necessarily estimated in this subspace.
@@ -264,6 +272,7 @@ class ModelSubspace(PetabMixin):
 
         # Parameters related to minimal changes compared to the predecessor model.
         old_estimated = set(old_estimated_all).intersection(self.can_estimate)
+        old_fixed = set(old_fixed_all).intersection(self.can_fix)
         new_must_estimate = set(new_must_estimate_all).intersection(
             self.parameters
         )
@@ -310,8 +319,10 @@ class ModelSubspace(PetabMixin):
                 # can be fixed, will be fixed.
                 estimated_parameters = {
                     parameter_id: ESTIMATE
-                    for parameter_id in set(self.parameters).difference(
-                        self.can_fix
+                    for parameter_id in (
+                        set(self.parameters)
+                        .difference(self.can_fix)
+                        .union(old_estimated)
                     )
                 }
                 models = self.get_models(
@@ -400,8 +411,10 @@ class ModelSubspace(PetabMixin):
                 # estimated.
                 estimated_parameters = {
                     parameter_id: ESTIMATE
-                    for parameter_id in set(self.parameters).difference(
-                        self.must_fix
+                    for parameter_id in (
+                        set(self.parameters)
+                        .difference(self.must_fix)
+                        .difference(old_fixed)
                     )
                 }
                 models = self.get_models(

--- a/petab_select/model_subspace.py
+++ b/petab_select/model_subspace.py
@@ -313,10 +313,8 @@ class ModelSubspace(PetabMixin):
                 new_must_estimate_all
                 or candidate_space.predecessor_model == VIRTUAL_INITIAL_MODEL
             ):
-                # Consider minimal models that have all necessary parameters
-                # estimated. As this subspace necessarily has more estimated
-                # parameters than the predecessor model, all parameters that
-                # can be fixed, will be fixed.
+                # Consider minimal models that have all necessarily-estimated
+                # parameters.
                 estimated_parameters = {
                     parameter_id: ESTIMATE
                     for parameter_id in (
@@ -405,10 +403,8 @@ class ModelSubspace(PetabMixin):
                 new_must_fix_all
                 or candidate_space.predecessor_model == VIRTUAL_INITIAL_MODEL
             ):
-                # Consider minimal models that have all necessarily fixed parameters.
-                # As this subspace necessarily has fewer estimated parameters than the
-                # predecessor model, all parameters that can be estimated, will be
-                # estimated.
+                # Consider minimal models that have all necessarily-fixed
+                # parameters.
                 estimated_parameters = {
                     parameter_id: ESTIMATE
                     for parameter_id in (


### PR DESCRIPTION
This fixes a major bug in the stepwise logic.

Consider the model space table
| model_subspace_id | petab_yaml              | k1         | k2         |
|-------------------|-------------------------|------------|------------|
| M1                | full_petab_problem.yaml | 1;estimate | 1;estimate |
| M2                | full_petab_problem.yaml | 1;estimate | 1          |

Let the current model in a backward search be in `M1`, with `k1=1, k2=estimate`.

Valid backward moves are `k1=1 and k2=1` in `M2`, and `k1=1 and k2=1` in `M2`.

`M2` will never return `k1=1 and k2=1`. The current logic first checks the largest possible model in the space, then all combinations involving at least one "optionally fixed" parameter. `k1` is not "optionally fixed" -- it must be fixed based on the current model. Hence, no model is returned from `M2`.

This PR changes the logic so that the first check is now "largest possible model in the space, but fix the parameters that were fixed in the other model subspace", and the corresponding fix for the forward moves.

An alternative fix would be to remove these lines from the backward method:
https://github.com/PEtab-dev/petab_select/blob/316b4375b20af23c171e8ab4924f54ac3f0aa2bd/petab_select/model_subspace.py#L435-L439