### PR TITLE
Fix argument order in `calculate_aicc`

### DIFF
--- a/petab_select/criteria.py
+++ b/petab_select/criteria.py
@@ -203,9 +203,11 @@ def calculate_aicc(
     Returns:
         The AICc value.
     """
-    return calculate_aic(n_estimated, nllh) + 2 * n_estimated * (
-        n_estimated + 1
-    ) / (n_measurements + n_priors - n_estimated - 1)
+    return calculate_aic(
+        nllh=nllh, n_estimated=n_estimated
+    ) + 2 * n_estimated * (n_estimated + 1) / (
+        n_measurements + n_priors - n_estimated - 1
+    )
 
 
 def calculate_bic(


### PR DESCRIPTION
Fix argument order in calculate_aicc. nllh was used as n_estimated and vice versa when computing AIC.