### PR TITLE
Sort dictionaries used in hashes, for reproducibility

### DIFF
--- a/petab_select/misc.py
+++ b/petab_select/misc.py
@@ -31,7 +31,7 @@ def hashify(x: Any) -> str:
 
 def hash_parameter_dict(dict_: TYPE_PARAMETER_DICT):
     """Hash a dictionary of parameter values."""
-    value = tuple(zip(dict_.keys(), dict_.values()))
+    value = tuple((k, dict_[k]) for k in sorted(dict_))
     return hashify(value)
 
 

--- a/petab_select/model_subspace.py
+++ b/petab_select/model_subspace.py
@@ -101,7 +101,7 @@ class ModelSubspace(PetabMixin):
                 '(e.g. forward or backward). '
                 f'This model subspace: `{self.model_subspace_id}`. '
                 'This model subspace PEtab YAML: '
-                f'`{self.petab_yaml}`.'
+                f'`{self.petab_yaml}`. '
                 'The candidate space PEtab YAML: '
                 f'`{candidate_space.predecessor_model.petab_yaml}`. '
             )


### PR DESCRIPTION
Currently, the `model.estimated_parameters` dictionary can change order between jobs, which results in the same model have different hashes across jobs. This fixes that.