### PR TITLE
Nicer model hashes; `model_hash_to_model` method

### DIFF
--- a/petab_select/constants.py
+++ b/petab_select/constants.py
@@ -1,8 +1,8 @@
 """Constants for the PEtab Select package."""
+import string
 import sys
 from enum import Enum
 from pathlib import Path
-import string
 from typing import Dict, List, Literal, Union
 
 # Zero-indexed column/row indices
@@ -33,9 +33,11 @@ MODEL_SUBSPACE_INDICES = 'model_subspace_indices'
 MODEL_CODE = 'model_code'
 MODEL_HASH = 'model_hash'
 MODEL_HASHES = 'model_hashes'
-MODEL_SUBSPACE_INDICES_HASH_MAP = (  # [0-9]+[A-Z]+[a-z]
-    ''.join(str(i) for i in range(10))
-    + string.ascii_uppercase + string.ascii_lowercase
+MODEL_SUBSPACE_INDICES_HASH_MAP = (
+    # [0-9]+[A-Z]+[a-z]
+    string.digits
+    + string.ascii_uppercase
+    + string.ascii_lowercase
 )
 MODEL_HASH_DELIMITER = '.'
 HASHED_MODEL_SUBSPACE_INDICES_DELIMITER = '-'

--- a/petab_select/constants.py
+++ b/petab_select/constants.py
@@ -39,8 +39,8 @@ MODEL_SUBSPACE_INDICES_HASH_MAP = (
     + string.ascii_uppercase
     + string.ascii_lowercase
 )
-MODEL_HASH_DELIMITER = '.'
-HASHED_MODEL_SUBSPACE_INDICES_DELIMITER = '-'
+MODEL_HASH_DELIMITER = '-'
+HASHED_MODEL_SUBSPACE_INDICES_DELIMITER = '.'
 # If `predecessor_model_hash` is defined for a model, it is the ID of the model that the
 # current model was/is to be compared to. This is part of the result and is
 # only (optionally) set by the PEtab calibration tool. It is not defined by the

--- a/petab_select/constants.py
+++ b/petab_select/constants.py
@@ -33,14 +33,14 @@ MODEL_SUBSPACE_INDICES = 'model_subspace_indices'
 MODEL_CODE = 'model_code'
 MODEL_HASH = 'model_hash'
 MODEL_HASHES = 'model_hashes'
+MODEL_HASH_DELIMITER = '-'
+MODEL_SUBSPACE_INDICES_HASH_DELIMITER = '.'
 MODEL_SUBSPACE_INDICES_HASH_MAP = (
     # [0-9]+[A-Z]+[a-z]
     string.digits
     + string.ascii_uppercase
     + string.ascii_lowercase
 )
-MODEL_HASH_DELIMITER = '-'
-HASHED_MODEL_SUBSPACE_INDICES_DELIMITER = '.'
 # If `predecessor_model_hash` is defined for a model, it is the ID of the model that the
 # current model was/is to be compared to. This is part of the result and is
 # only (optionally) set by the PEtab calibration tool. It is not defined by the

--- a/petab_select/constants.py
+++ b/petab_select/constants.py
@@ -2,6 +2,7 @@
 import sys
 from enum import Enum
 from pathlib import Path
+import string
 from typing import Dict, List, Literal, Union
 
 # Zero-indexed column/row indices
@@ -32,6 +33,12 @@ MODEL_SUBSPACE_INDICES = 'model_subspace_indices'
 MODEL_CODE = 'model_code'
 MODEL_HASH = 'model_hash'
 MODEL_HASHES = 'model_hashes'
+MODEL_SUBSPACE_INDICES_HASH_MAP = (  # [0-9]+[A-Z]+[a-z]
+    ''.join(str(i) for i in range(10))
+    + string.ascii_uppercase + string.ascii_lowercase
+)
+MODEL_HASH_DELIMITER = '.'
+HASHED_MODEL_SUBSPACE_INDICES_DELIMITER = '-'
 # If `predecessor_model_hash` is defined for a model, it is the ID of the model that the
 # current model was/is to be compared to. This is part of the result and is
 # only (optionally) set by the PEtab calibration tool. It is not defined by the

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -773,9 +773,11 @@ def hash_model(model: Model):
             MODEL_SUBSPACE_INDICES_HASH_MAP[index]
             for index in model.model_subspace_indices
         )
-    except:
-        hashed_model_subspace_indices = HASHED_MODEL_SUBSPACE_INDICES_DELIMITER.join(
-            str(i) for i in model.model_subspace_indices
+    except KeyError:
+        hashed_model_subspace_indices = (
+            HASHED_MODEL_SUBSPACE_INDICES_DELIMITER.join(
+                str(i) for i in model.model_subspace_indices
+            )
         )
 
     model_hash = (

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -743,7 +743,7 @@ def models_to_yaml_list(
         yaml.dump(model_dicts, f)
 
 
-def unhash_model(model_hash: str):
+def unhash_model(model_hash: str) -> tuple[str, list[int]]:
     """Convert a model hash into model subspace information.
 
     Args:

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -899,13 +899,19 @@ class ModelHash(str):
         Returns:
             The model hash.
         """
-        return ModelHash(
-            model_subspace_id=model.model_subspace_id,
-            model_subspace_indices_hash=(
+        model_subspace_id = ''
+        model_subspace_indices_hash = ''
+        if model.model_subspace_id is not None:
+            model_subspace_id = model.model_subspace_id
+            model_subspace_indices_hash = (
                 ModelHash.hash_model_subspace_indices(
-                    model.model_subspace_indices,
+                    model.model_subspace_indices
                 )
-            ),
+            )
+
+        return ModelHash(
+            model_subspace_id=model_subspace_id,
+            model_subspace_indices_hash=model_subspace_indices_hash,
             petab_hash=ModelHash.get_petab_hash(model=model),
         )
 

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -766,10 +766,10 @@ class ModelHash(str):
     `ModelHash`s `model_hash0` and `model_hash1`, respectively. Assume that
     these two models end up encoding the same PEtab problem (e.g. they set the
     same parameters to be estimated).
-    The string and hash representations will be different,
-    `str(model_hash0) != str(model_hash1)` and
-    `hash(model_hash0) != hash(model_hash1)`, but their hashes will pass the
-    equality check `model_hash0 == model_hash1`.
+    The string representation will be different,
+    `str(model_hash0) != str(model_hash1)`, but their hashes will pass the
+    equality check: `model_hash0 == model_hash1` and
+    `hash(model_hash0) == hash(model_hash1)`.
 
     This means that different models in different model subspaces that end up
     being the same PEtab problem will have different human-readable hashes,

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -753,7 +753,7 @@ def unhash_model(model_hash: str):
         in hashed_model_subspace_indices
     ):
         model_subspace_indices = [
-            int[s]
+            int(s)
             for s in hashed_model_subspace_indices.split(
                 HASHED_MODEL_SUBSPACE_INDICES_DELIMITER
             )
@@ -774,7 +774,7 @@ def hash_model(model: Model):
             for index in model.model_subspace_indices
         )
     except:
-        hashed_model_subspace_indices = '_'.join(
+        hashed_model_subspace_indices = HASHED_MODEL_SUBSPACE_INDICES_DELIMITER.join(
             str(i) for i in model.model_subspace_indices
         )
 

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -1,8 +1,8 @@
 """The `Model` class."""
+import string
 import warnings
 from os.path import relpath
 from pathlib import Path
-import string
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import petab
@@ -744,9 +744,14 @@ def models_to_yaml_list(
 
 
 def unhash_model(model_hash: str):
-    model_subspace_id, hashed_model_subspace_indices = model_hash.split(MODEL_HASH_DELIMITER)
+    model_subspace_id, hashed_model_subspace_indices = model_hash.split(
+        MODEL_HASH_DELIMITER
+    )
 
-    if HASHED_MODEL_SUBSPACE_INDICES_DELIMITER in hashed_model_subspace_indices:
+    if (
+        HASHED_MODEL_SUBSPACE_INDICES_DELIMITER
+        in hashed_model_subspace_indices
+    ):
         model_subspace_indices = [
             int[s]
             for s in hashed_model_subspace_indices.split(
@@ -773,5 +778,9 @@ def hash_model(model: Model):
             str(i) for i in model.model_subspace_indices
         )
 
-    model_hash = model.model_subspace_id + MODEL_HASH_DELIMITER + hashed_model_subspace_indices
+    model_hash = (
+        model.model_subspace_id
+        + MODEL_HASH_DELIMITER
+        + hashed_model_subspace_indices
+    )
     return model_hash

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -744,6 +744,17 @@ def models_to_yaml_list(
 
 
 def unhash_model(model_hash: str):
+    """Convert a model hash into model subspace information.
+
+    Args:
+        model_hash:
+            The model hash, in the format produced by :func:`hash_model`.
+
+    Returns:
+        The model subspace ID, and the indices that correspond to a unique
+        model in the subspace. The indices can be converted to a model with
+        the `ModelSubspace.indices_to_model` method.
+    """
     model_subspace_id, hashed_model_subspace_indices = model_hash.split(
         MODEL_HASH_DELIMITER
     )
@@ -767,7 +778,17 @@ def unhash_model(model_hash: str):
     return model_subspace_id, model_subspace_indices
 
 
-def hash_model(model: Model):
+def hash_model(model: Model) -> str:
+    """Create a unique hash for a model.
+
+    Args:
+        model:
+            The model.
+
+    Returns:
+        The hash. The format is the model subspace followed by a representation
+        of the indices of the model parameters in its subspace.
+    """
     try:
         hashed_model_subspace_indices = ''.join(
             MODEL_SUBSPACE_INDICES_HASH_MAP[index]

--- a/petab_select/model.py
+++ b/petab_select/model.py
@@ -485,12 +485,18 @@ class Model(PetabMixin):
     def get_hash(self) -> int:
         """Get the model hash.
 
-        Currently designed to only use pre-calibration information, such that if a model
-        is calibrated twice and the two calibrated models differ in their parameter
-        estimates, then they will still have the same hash.
+        Hashes are only unique to a specific PEtab Select problem. If the
+        problem is changed, then an old hash may now refer to a different
+        model. A hash currently only contains the ID of the model subspace that
+        the model belongs to, and the location of the model in its subspace.
 
-        This is not implemented as ``__hash__`` because Python automatically truncates
-        values in a system-dependent manner, which reduces interoperability
+        Hashes only use pre-calibration information, such that if a model
+        is calibrated twice and the two calibrated models differ in their
+        parameter estimates, then they will still have the same hash.
+
+        This is not implemented as ``__hash__`` because Python automatically
+        truncates values in a system-dependent manner, which reduces
+        interoperability
         ( https://docs.python.org/3/reference/datamodel.html#object.__hash__ ).
 
         Returns:

--- a/petab_select/problem.py
+++ b/petab_select/problem.py
@@ -17,7 +17,7 @@ from .constants import (
     Criterion,
     Method,
 )
-from .model import Model, default_compare, unhash_model
+from .model import Model, ModelHash, default_compare
 from .model_space import ModelSpace
 
 __all__ = [
@@ -239,24 +239,19 @@ class Problem(abc.ABC):
             )
         return best_model
 
-    def model_hash_to_model(self, model_hash: str) -> Model:
+    def model_hash_to_model(self, model_hash: Union[str, ModelHash]) -> Model:
         """Get the model that matches a model hash.
 
         Args:
             model_hash:
-                The model hash, in the format produced by
-                :func:`petab_select.model.hash_model`.
+                The model hash.
 
         Returns:
             The model.
         """
-        model_subspace_id, model_subspace_indices = unhash_model(model_hash)
-        model = self.model_space.model_subspaces[
-            model_subspace_id
-        ].indices_to_model(
-            indices=model_subspace_indices,
+        return ModelHash.from_hash(model_hash).get_model(
+            petab_select_problem=self,
         )
-        return model
 
     def new_candidate_space(
         self,

--- a/petab_select/problem.py
+++ b/petab_select/problem.py
@@ -239,7 +239,17 @@ class Problem(abc.ABC):
             )
         return best_model
 
-    def model_hash_to_model(self, model_hash: str):
+    def model_hash_to_model(self, model_hash: str) -> Model:
+        """Get the model that matches a model hash.
+
+        Args:
+            model_hash:
+                The model hash, in the format produced by
+                :func:`petab_select.model.hash_model`.
+
+        Returns:
+            The model.
+        """
         model_subspace_id, model_subspace_indices = unhash_model(model_hash)
         model = self.model_space.model_subspaces[
             model_subspace_id

--- a/petab_select/problem.py
+++ b/petab_select/problem.py
@@ -241,7 +241,9 @@ class Problem(abc.ABC):
 
     def model_hash_to_model(self, model_hash: str):
         model_subspace_id, model_subspace_indices = unhash_model(model_hash)
-        model = self.model_space.model_subspaces[model_subspace_id].indices_to_model(
+        model = self.model_space.model_subspaces[
+            model_subspace_id
+        ].indices_to_model(
             indices=model_subspace_indices,
         )
         return model

--- a/petab_select/problem.py
+++ b/petab_select/problem.py
@@ -17,7 +17,7 @@ from .constants import (
     Criterion,
     Method,
 )
-from .model import Model, default_compare
+from .model import Model, default_compare, unhash_model
 from .model_space import ModelSpace
 
 __all__ = [
@@ -238,6 +238,13 @@ class Problem(abc.ABC):
                 f'None of the supplied models have a value set for the criterion {criterion}.'
             )
         return best_model
+
+    def model_hash_to_model(self, model_hash: str):
+        model_subspace_id, model_subspace_indices = unhash_model(model_hash)
+        model = self.model_space.model_subspaces[model_subspace_id].indices_to_model(
+            indices=model_subspace_indices,
+        )
+        return model
 
     def new_candidate_space(
         self,

--- a/test/model_space/test_model_space.py
+++ b/test/model_space/test_model_space.py
@@ -75,9 +75,9 @@ def test_model_space_backward_virtual(model_space):
     candidate_space = BackwardCandidateSpace()
     model_space.search(candidate_space)
 
-    # The forward candidate space is initialized without a model, so a virtual initial
-    # model is used. This means the expected models are the "smallest" models (as many
-    # fixed parameters as possible) in the model space.
+    # The backward candidate space is initialized without a model, so a virtual
+    # initial model is used. This means the expected models are the "smallest"
+    # models (as many fixed parameters as possible) in the model space.
     expected_models = [
         ('model_subspace_1', {f'k{i}': ESTIMATE for i in range(1, 5)}),
         # This model is not included because it is exactly the same as the


### PR DESCRIPTION
Model hashes are now `{MODEL_SUBSPACE_ID}-{MODEL_SUBSPACE_INDICES}-{PETAB_HASH}`.

This makes possible a `petab_select_problem.model_hash_to_model` method, that converts a model hash into a model.

For parameters with > 10 options, alphabet characters will be used (similar to hex, but now 62 characters from `[0-9][A-Z][a-z]`. For parameters with > 62 options, the actual index delimited by `.` will be used.
e.g.
`[estimate, 0, estimate, 0, 0]` (values) -> `[1,0,1,0,0]` (indices) -> `model_subspace_A-10100-petab_hash` (hash)
`[1, 36, 0]` (indices) -> `model_subspace_A-1Z0-petab_hash` (hash)
`[1, 63, 0]` (indices) -> `model_subspace_A-1.63.0-petab_hash` (hash)

Also possible to just go with the last option with `.`s for simpler implementation and broad applicability. However, I expect most users will have parameters that can only be one of `(0, estimate}`, in which case all indices will be one of `{0, 1}`, so the more compact first representation is probably preferred.

The PEtab hash is computed from only the following information:
- absolute location of the PEtab problem YAML file in the filesystem
- nominal values of parameters in the model's PEtab problem
- estimated parameters in the model's PEtab problem