### PR TITLE
GHA: Add PyPI deployment workflow

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,0 +1,34 @@
+name: Deploy
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  pypi:
+    name: Deploy PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/petab-select
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 20
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel build
+        python -m build -s
+
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
On release, deploy package to PyPI.

Related to #89 