### PR TITLE
Fix minimum Python requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # test on latest and minimum python version
-        python-version: ['3.11', '3.9']
+        python-version: ['3.12', '3.10']
 
     steps:
     - name: Check out repository

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ def absolute_links(txt):
     return txt
 
 
-# 3.7.1 for NumPy, 3.8 for `typing.get_args`
-minimum_python_version = '3.8'
+minimum_python_version = '3.10'
 if sys.version_info < tuple(map(int, minimum_python_version.split('.'))):
     sys.exit(f'PEtab Select requires Python >= {minimum_python_version}')
 


### PR DESCRIPTION
petab requires python>=3.10

Related to #94.