### PR TITLE
Set up setuptools_scm

### DIFF
--- a/petab_select/version.py
+++ b/petab_select/version.py
@@ -1,2 +1,0 @@
-"""Version of the model selection extension for PEtab."""
-__version__ = '0.1.13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,60 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "petab_select"
+dynamic = ["version"]
+maintainers = [
+    {name = "Dilan Pathirana", email = "dilan.pathirana@uni-bonn.de"},
+]
+authors = [
+    {name = "The PEtab Select developers"},
+]
+description = "PEtab Select: an extension to PEtab for model selection."
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "BSD-3-Clause"}
+dependencies = [
+    # TODO minimum versions
+    "more-itertools",
+    "numpy",
+    "pandas",
+    "petab",
+    "pyyaml",
+    "click",
+    "dill",
+]
+[project.optional-dependencies]
+test = [
+    "pytest >= 5.4.3",
+    "pytest-cov >= 2.10.0",
+    "amici >= 0.11.25",
+    "fides >= 0.7.5",
+    "pypesto > 0.2.13",
+    "tox >= 3.12.4",
+    "flake8 >= 4.0.1",
+]
+doc = [
+    "sphinx>=3.5.3,<7",
+    "sphinxcontrib-napoleon>=0.7",
+    "sphinx-markdown-tables>=0.0.15",
+    "sphinx-rtd-theme>=0.5.1",
+    "recommonmark>=0.7.1",
+    # pin until ubuntu comes with newer pandoc:
+    # /home/docs/checkouts/readthedocs.org/user_builds/petab-select/envs/63/lib/python3.11/site-packages/nbsphinx/__init__.py:1058: RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
+    # Your version must be at least (2.14.2) but less than (4.0.0).
+    "nbsphinx==0.9.1",
+    "nbconvert<7.5.0",
+    "ipython>=7.21.0",
+    "readthedocs-sphinx-ext>=2.2.5",
+    "sphinx-autodoc-typehints",
+]
+
+[project.scripts]
+petab_select = "petab_select.cli:cli"
+
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 79

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+git+https://github.com/ICB-DCM/pyPESTO.git@select_use_old_calibrations#egg=pypesto
 tox >= 3.12.4
 pre-commit >= 2.10.1
 flake8 >= 4.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ICB-DCM/pyPESTO.git@select_use_old_calibrations#egg=pypesto
+git+https://github.com/ICB-DCM/pyPESTO.git@develop#egg=pypesto
 tox >= 3.12.4
 pre-commit >= 2.10.1
 flake8 >= 4.0.1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 
 from setuptools import find_packages, setup
 
@@ -30,79 +29,12 @@ def absolute_links(txt):
     return txt
 
 
-minimum_python_version = '3.10'
-if sys.version_info < tuple(map(int, minimum_python_version.split('.'))):
-    sys.exit(f'PEtab Select requires Python >= {minimum_python_version}')
-
-# read version from file
-__version__ = ''
-version_file = os.path.join('petab_select', 'version.py')
-# sets __version__
-exec(read(version_file))  # pylint: disable=W0122 # nosec
-
-ENTRY_POINTS = {
-    'console_scripts': [
-        'petab_select = petab_select.cli:cli',
-    ]
-}
-
 # project metadata
 # noinspection PyUnresolvedReferences
 setup(
-    name='petab_select',
-    version=__version__,
-    description='PEtab Select: an extension to PEtab for model selection.',
     long_description=absolute_links(read('README.md')),
     long_description_content_type="text/markdown",
-    # author='The PEtab Select developers',
-    # author_email='dilan.pathirana@uni-bonn.de',
     url=f'https://github.com/{org}/{repo}',
     packages=find_packages(exclude=['doc*', 'test*']),
-    install_requires=[
-        # TODO minimum versions
-        'more-itertools',
-        'numpy',
-        'pandas',
-        'petab',
-        'pyyaml',
-        #'python-libsbml>=5.17.0',
-        #'sympy',
-        # required for CLI
-        'click',
-        'dill',
-        # plotting
-        #'matplotlib>=2.2.3',
-        #'seaborn',
-    ],
     include_package_data=True,
-    python_requires=f'>={minimum_python_version}',
-    entry_points=ENTRY_POINTS,
-    extras_require={
-        'test': [
-            'pytest >= 5.4.3',
-            'pytest-cov >= 2.10.0',
-            'amici >= 0.11.25',
-            'fides >= 0.7.5',
-            # FIXME
-            # 'pypesto > 0.2.13',
-            'pypesto @ git+https://github.com/ICB-DCM/pyPESTO.git@select_use_old_calibrations#egg=pypesto',
-            'tox >= 3.12.4',
-            'flake8 >= 4.0.1',
-        ],
-        'doc': [
-            'sphinx>=3.5.3,<7',
-            'sphinxcontrib-napoleon>=0.7',
-            'sphinx-markdown-tables>=0.0.15',
-            'sphinx-rtd-theme>=0.5.1',
-            'recommonmark>=0.7.1',
-            # pin until ubuntu comes with newer pandoc:
-            # /home/docs/checkouts/readthedocs.org/user_builds/petab-select/envs/63/lib/python3.11/site-packages/nbsphinx/__init__.py:1058: RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
-            # Your version must be at least (2.14.2) but less than (4.0.0).
-            'nbsphinx==0.9.1',
-            'nbconvert<7.5.0',
-            'ipython>=7.21.0',
-            'readthedocs-sphinx-ext>=2.2.5',
-            'sphinx-autodoc-typehints',
-        ],
-    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ description =
 
 [testenv:base]
 extras = test
+deps =
+    git+https://github.com/ICB-DCM/pyPESTO.git@select_use_old_calibrations#egg=pypesto
 commands =
   pytest --cov=petab_select --cov-report=xml --cov-append test -s
   coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ description =
 [testenv:base]
 extras = test
 deps =
-    git+https://github.com/ICB-DCM/pyPESTO.git@select_use_old_calibrations\#egg=pypesto
+    git+https://github.com/ICB-DCM/pyPESTO.git@develop\#egg=pypesto
 commands =
   pytest --cov=petab_select --cov-report=xml --cov-append test -s
   coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ description =
 [testenv:base]
 extras = test
 deps =
-    git+https://github.com/ICB-DCM/pyPESTO.git@select_use_old_calibrations#egg=pypesto
+    git+https://github.com/ICB-DCM/pyPESTO.git@select_use_old_calibrations\#egg=pypesto
 commands =
   pytest --cov=petab_select --cov-report=xml --cov-append test -s
   coverage report


### PR DESCRIPTION
Set up `setuptools_scm` and move most package configuration to `pyproject.toml`.

Move git-based package URLs out of `pyproject.toml`/`setup.py` (otherwise, PyPI upload will fail).

