### PR TITLE
Unfix pypesto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ test = [
     "pytest-cov >= 2.10.0",
     "amici >= 0.11.25",
     "fides >= 0.7.5",
-    # "pypesto > 0.2.13",
-    "pypesto @ git+https://github.com/ICB-DCM/pyPESTO.git@select_mkstd#egg=pypesto",
+    "pypesto >= 0.5.4",
+    #"pypesto @ git+https://github.com/ICB-DCM/pyPESTO.git@select_mkstd#egg=pypesto",
     "tox >= 3.12.4",
 ]
 doc = [


### PR DESCRIPTION
Tests will fail until a release with https://github.com/ICB-DCM/pyPESTO/pull/1530

Require for publication to PyPI